### PR TITLE
feat: Implement Android App Links for sharing transaction groups

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -24,6 +24,12 @@
                 <action android:name="android.intent.action.MAIN"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="splitter-2e1ae.web.app" android:pathPrefix="/join" />
+            </intent-filter>
         </activity>
         <!-- Don't delete the meta-data below.
              This is used by the Flutter tool to generate GeneratedPluginRegistrant.java -->

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,9 @@
 // lib/main.dart
+import 'dart:async'; // Required for StreamSubscription
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart'; // Required for PlatformException
 import 'package:provider/provider.dart';
+import 'package:uni_links/uni_links.dart';
 import 'providers/app_state.dart';
 import 'screens/home_screen.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -19,22 +22,92 @@ void main() async {
     runApp(
       ChangeNotifierProvider(
         create: (_) => AppState(),
-        child: TransactionSettlementApp(),
+        child: AppWithLinkHandler(), // Changed to AppWithLinkHandler
       ),
     );
   } catch (e) {
     print("Firebase initialization failed: $e");
   }
-  
-  // print("running app...");
-  // runApp(
-  //   ChangeNotifierProvider(
-  //     create: (_) => AppState(),
-  //     child: TransactionSettlementApp(),
-  //   ),
-  // );
 }
 
+class AppWithLinkHandler extends StatefulWidget {
+  @override
+  _AppWithLinkHandlerState createState() => _AppWithLinkHandlerState();
+}
+
+class _AppWithLinkHandlerState extends State<AppWithLinkHandler> {
+  StreamSubscription? _sub;
+
+  @override
+  void initState() {
+    super.initState();
+    _initUniLinks();
+  }
+
+  @override
+  void dispose() {
+    _sub?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _initUniLinks() async {
+    try {
+      final initialUri = await getInitialUri();
+      if (initialUri != null) {
+        _handleLink(context, initialUri);
+      }
+    } on PlatformException {
+      // Platform messages may fail, so we use a try/catch PlatformException.
+      print("Failed to get initial link.");
+    } on FormatException {
+      print("Failed to parse initial link.");
+    }
+
+    _sub = uriLinkStream.listen((Uri? uri) {
+      if (uri != null) {
+        _handleLink(context, uri);
+      }
+    }, onError: (err) {
+      print('uriLinkStream error: $err');
+    });
+  }
+
+  void _handleLink(BuildContext context, Uri? link) {
+    if (link == null) return;
+
+    print("Handling link: $link");
+    if (link.scheme == 'https' &&
+        link.host == 'splitter-2e1ae.web.app' &&
+        link.pathSegments.isNotEmpty &&
+        link.pathSegments.first == 'join') {
+      final token = link.queryParameters['token'];
+      if (token != null && token.isNotEmpty) {
+        print("Extracted token: $token");
+        try {
+          final appState = Provider.of<AppState>(context, listen: false);
+          appState.joinTransactionGroup(token);
+          scaffoldMessengerKey.currentState?.showSnackBar(
+            SnackBar(content: Text('Joining group with token: $token')),
+          );
+        } catch (e) {
+          print("Error joining group from link: $e");
+          scaffoldMessengerKey.currentState?.showSnackBar(
+            SnackBar(content: Text('Error joining group: ${e.toString()}')),
+          );
+        }
+      } else {
+        print("Token not found in link");
+      }
+    } else {
+      print("Link not recognized as a join link.");
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return TransactionSettlementApp(); // The original app root
+  }
+}
 
 class TransactionSettlementApp extends StatelessWidget {
   const TransactionSettlementApp({super.key});

--- a/lib/screens/transaction_group_screen.dart
+++ b/lib/screens/transaction_group_screen.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter/services.dart';
+import 'package:share_plus/share_plus.dart';
 import 'package:splitter/screens/home_screen.dart';
 import '../providers/app_state.dart';
 import 'add_transaction_screen.dart';
@@ -183,21 +184,31 @@ class TransactionGroupScreen extends StatelessWidget {
               icon: Icon(Icons.share),
               tooltip: 'Share',
               onPressed: () async {
-                // Copy the transaction group inviteToken to the clipboard
-                final inviteToken = appState.currentTransactionGroup!.inviteToken;
                 final messenger = ScaffoldMessenger.of(context); // Capture before async call
-                try {
-                  await Clipboard.setData(ClipboardData(text: inviteToken));
+                final inviteToken = appState.currentTransactionGroup?.inviteToken;
+                if (inviteToken == null || inviteToken.isEmpty) {
                   messenger.showSnackBar(
                     SnackBar(
-                      content: Text('Invite token copied to clipboard'),
+                      content: Text('Invite token is not available.'),
+                      duration: Duration(seconds: 2),
+                    ),
+                  );
+                  return;
+                }
+                String appLink = "https://splitter-2e1ae.web.app/join?token=$inviteToken";
+                try {
+                  await Share.share('Join my transaction group on Splitter! $appLink');
+                  // Optionally, if you still want a SnackBar confirmation:
+                  messenger.showSnackBar(
+                    SnackBar(
+                      content: Text('Share dialog initiated.'),
                       duration: Duration(seconds: 2),
                     ),
                   );
                 } catch (error) {
                   messenger.showSnackBar(
                     SnackBar(
-                      content: Text('Failed to copy invite token'),
+                      content: Text('Failed to initiate share: $error'),
                       duration: Duration(seconds: 2),
                     ),
                   );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,7 @@ dependencies:
   flutter:
     sdk: flutter
   provider: ^6.1.2
+  share_plus: ^9.0.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -41,6 +42,7 @@ dependencies:
   google_sign_in: ^6.2.2
   uuid: ^4.2.2
   cloud_functions: ^5.2.0
+  uni_links: ^0.5.1
   
 
 dev_dependencies:


### PR DESCRIPTION
This feature streamlines the process of joining a transaction group by introducing Android App Links.

Key changes include:
- Modified AndroidManifest.xml to register the app to handle URLs of the format https://splitter-2e1ae.web.app/join.
- Updated the sharing functionality in the TransactionGroupScreen to generate and share these app links using the `share_plus` package.
- Implemented app link handling in `main.dart` using the `uni_links` package to parse incoming links, extract the invite token, and automatically attempt to join the group.
- Added `share_plus` and `uni_links` to pubspec.yaml.

You can now share a direct link to a transaction group. When another user opens this link, the app will launch and automatically process the invitation, adding them to the group. This replaces the previous method of manually copying and pasting invite tokens.